### PR TITLE
Add MakeOffer

### DIFF
--- a/gen/bag_connect.ts
+++ b/gen/bag_connect.ts
@@ -3,7 +3,7 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { CloseTradeRequest, CloseTradeResponse, CreateActionRequest, CreateActionResponse, CreateAppRequest, CreateAppResponse, CreateInstanceRequest, CreateInstanceResponse, CreateInstancesRequest, CreateInstancesResponse, CreateItemRequest, CreateItemResponse, CreateRecipeRequest, CreateRecipeResponse, CreateTradeRequest, CreateTradeResponse, DeleteAppRequest, DeleteAppResponse, DeleteInstanceRequest, DeleteInstanceResponse, DeleteTradeRequest, DeleteTradeResponse, GetActionRequest, GetActionResponse, GetAppRequest, GetAppResponse, GetCraftStatusRequest, GetCraftStatusResponse, GetIdentitiesRequest, GetIdentitiesResponse, GetIdentityRequest, GetIdentityResponse, GetInstanceRequest, GetInstanceResponse, GetInventoryRequest, GetInventoryResponse, GetItemRequest, GetItemResponse, GetItemsRequest, GetItemsResponse, GetRecipeRequest, GetRecipeResponse, GetRecipesRequest, GetRecipesResponse, GetTradeRequest, GetTradeResponse, GetTradesRequest, GetTradesResponse, RunCraftRequest, RunCraftResponse, RunGiveRequest, RunGiveResponse, UpdateActionRequest, UpdateActionResponse, UpdateAppRequest, UpdateAppResponse, UpdateIdentityMetadataRequest, UpdateIdentityMetadataResponse, UpdateInstanceRequest, UpdateInstanceResponse, UpdateItemRequest, UpdateItemResponse, UpdateRecipeRequest, UpdateRecipeResponse, UpdateTradeRequest, UpdateTradeResponse, VerifyKeyRequest, VerifyKeyResponse } from "./bag_pb.js";
+import { CloseTradeRequest, CloseTradeResponse, CreateActionRequest, CreateActionResponse, CreateAppRequest, CreateAppResponse, CreateInstanceRequest, CreateInstanceResponse, CreateInstancesRequest, CreateInstancesResponse, CreateItemRequest, CreateItemResponse, CreateRecipeRequest, CreateRecipeResponse, CreateTradeRequest, CreateTradeResponse, DeleteAppRequest, DeleteAppResponse, DeleteInstanceRequest, DeleteInstanceResponse, DeleteTradeRequest, DeleteTradeResponse, GetActionRequest, GetActionResponse, GetAppRequest, GetAppResponse, GetCraftStatusRequest, GetCraftStatusResponse, GetIdentitiesRequest, GetIdentitiesResponse, GetIdentityRequest, GetIdentityResponse, GetInstanceRequest, GetInstanceResponse, GetInventoryRequest, GetInventoryResponse, GetItemRequest, GetItemResponse, GetItemsRequest, GetItemsResponse, GetRecipeRequest, GetRecipeResponse, GetRecipesRequest, GetRecipesResponse, GetTradeRequest, GetTradeResponse, GetTradesRequest, GetTradesResponse, MakeOfferRequest, MakeOfferResponse, RunCraftRequest, RunCraftResponse, RunGiveRequest, RunGiveResponse, UpdateActionRequest, UpdateActionResponse, UpdateAppRequest, UpdateAppResponse, UpdateIdentityMetadataRequest, UpdateIdentityMetadataResponse, UpdateInstanceRequest, UpdateInstanceResponse, UpdateItemRequest, UpdateItemResponse, UpdateRecipeRequest, UpdateRecipeResponse, UpdateTradeRequest, UpdateTradeResponse, VerifyKeyRequest, VerifyKeyResponse } from "./bag_pb.js";
 import { MethodKind } from "@bufbuild/protobuf";
 
 /**
@@ -316,6 +316,15 @@ export const BagService = {
       name: "GetCraftStatus",
       I: GetCraftStatusRequest,
       O: GetCraftStatusResponse,
+      kind: MethodKind.Unary,
+    },
+    /**
+     * @generated from rpc bag.BagService.MakeOffer
+     */
+    makeOffer: {
+      name: "MakeOffer",
+      I: MakeOfferRequest,
+      O: MakeOfferResponse,
       kind: MethodKind.Unary,
     },
   }

--- a/gen/bag_pb.ts
+++ b/gen/bag_pb.ts
@@ -4144,3 +4144,119 @@ export class GetCraftStatusResponse extends Message<GetCraftStatusResponse> {
   }
 }
 
+/**
+ * @generated from message bag.MakeOfferRequest
+ */
+export class MakeOfferRequest extends Message<MakeOfferRequest> {
+  /**
+   * @generated from field: int32 appId = 1;
+   */
+  appId = 0;
+
+  /**
+   * @generated from field: string key = 2;
+   */
+  key = "";
+
+  /**
+   * @generated from field: string sourceIdentityId = 3;
+   */
+  sourceIdentityId = "";
+
+  /**
+   * @generated from field: string targetIdentityId = 4;
+   */
+  targetIdentityId = "";
+
+  /**
+   * @generated from field: repeated bag.Instance offerToGive = 5;
+   */
+  offerToGive: Instance[] = [];
+
+  /**
+   * @generated from field: repeated bag.Instance offerToReceive = 6;
+   */
+  offerToReceive: Instance[] = [];
+
+  /**
+   * @generated from field: optional string callbackUrl = 7;
+   */
+  callbackUrl?: string;
+
+  constructor(data?: PartialMessage<MakeOfferRequest>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "bag.MakeOfferRequest";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "appId", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
+    { no: 2, name: "key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 3, name: "sourceIdentityId", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 4, name: "targetIdentityId", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 5, name: "offerToGive", kind: "message", T: Instance, repeated: true },
+    { no: 6, name: "offerToReceive", kind: "message", T: Instance, repeated: true },
+    { no: 7, name: "callbackUrl", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): MakeOfferRequest {
+    return new MakeOfferRequest().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): MakeOfferRequest {
+    return new MakeOfferRequest().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): MakeOfferRequest {
+    return new MakeOfferRequest().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: MakeOfferRequest | PlainMessage<MakeOfferRequest> | undefined, b: MakeOfferRequest | PlainMessage<MakeOfferRequest> | undefined): boolean {
+    return proto3.util.equals(MakeOfferRequest, a, b);
+  }
+}
+
+/**
+ * @generated from message bag.MakeOfferResponse
+ */
+export class MakeOfferResponse extends Message<MakeOfferResponse> {
+  /**
+   * @generated from field: optional string response = 1;
+   */
+  response?: string;
+
+  /**
+   * @generated from field: bool success = 2;
+   */
+  success = false;
+
+  constructor(data?: PartialMessage<MakeOfferResponse>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "bag.MakeOfferResponse";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "response", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
+    { no: 2, name: "success", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): MakeOfferResponse {
+    return new MakeOfferResponse().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): MakeOfferResponse {
+    return new MakeOfferResponse().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): MakeOfferResponse {
+    return new MakeOfferResponse().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: MakeOfferResponse | PlainMessage<MakeOfferResponse> | undefined, b: MakeOfferResponse | PlainMessage<MakeOfferResponse> | undefined): boolean {
+    return proto3.util.equals(MakeOfferResponse, a, b);
+  }
+}
+

--- a/prisma/migrations/20240621203448_add_offer_models/migration.sql
+++ b/prisma/migrations/20240621203448_add_offer_models/migration.sql
@@ -1,0 +1,19 @@
+-- AlterTable
+ALTER TABLE "Instance" ADD COLUMN     "offerToGiveId" INTEGER,
+ADD COLUMN     "offerToReceiveId" INTEGER;
+
+-- CreateTable
+CREATE TABLE "Offer" (
+    "id" SERIAL NOT NULL,
+    "sourceIdentityId" TEXT NOT NULL,
+    "targetIdentityId" TEXT NOT NULL,
+    "callbackUrl" TEXT,
+
+    CONSTRAINT "Offer_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "Instance" ADD CONSTRAINT "Instance_offerToGiveId_fkey" FOREIGN KEY ("offerToGiveId") REFERENCES "Offer"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Instance" ADD CONSTRAINT "Instance_offerToReceiveId_fkey" FOREIGN KEY ("offerToReceiveId") REFERENCES "Offer"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/migrations/20240624164546_offers_many_to_many/migration.sql
+++ b/prisma/migrations/20240624164546_offers_many_to_many/migration.sql
@@ -1,0 +1,44 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `offerToGiveId` on the `Instance` table. All the data in the column will be lost.
+  - You are about to drop the column `offerToReceiveId` on the `Instance` table. All the data in the column will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "Instance" DROP CONSTRAINT "Instance_offerToGiveId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Instance" DROP CONSTRAINT "Instance_offerToReceiveId_fkey";
+
+-- AlterTable
+ALTER TABLE "Instance" DROP COLUMN "offerToGiveId",
+DROP COLUMN "offerToReceiveId";
+
+-- CreateTable
+CREATE TABLE "InstanceOfferToGive" (
+    "instanceId" INTEGER NOT NULL,
+    "offerId" INTEGER NOT NULL,
+
+    CONSTRAINT "InstanceOfferToGive_pkey" PRIMARY KEY ("instanceId","offerId")
+);
+
+-- CreateTable
+CREATE TABLE "InstanceOfferToReceive" (
+    "instanceId" INTEGER NOT NULL,
+    "offerId" INTEGER NOT NULL,
+
+    CONSTRAINT "InstanceOfferToReceive_pkey" PRIMARY KEY ("instanceId","offerId")
+);
+
+-- AddForeignKey
+ALTER TABLE "InstanceOfferToGive" ADD CONSTRAINT "InstanceOfferToGive_instanceId_fkey" FOREIGN KEY ("instanceId") REFERENCES "Instance"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "InstanceOfferToGive" ADD CONSTRAINT "InstanceOfferToGive_offerId_fkey" FOREIGN KEY ("offerId") REFERENCES "Offer"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "InstanceOfferToReceive" ADD CONSTRAINT "InstanceOfferToReceive_instanceId_fkey" FOREIGN KEY ("instanceId") REFERENCES "Instance"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "InstanceOfferToReceive" ADD CONSTRAINT "InstanceOfferToReceive_offerId_fkey" FOREIGN KEY ("offerId") REFERENCES "Offer"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -62,16 +62,18 @@ model Item {
 }
 
 model Instance {
-  id         Int             @id @default(autoincrement())
-  itemId     String
-  identityId String?
-  item       Item            @relation(fields: [itemId], references: [name])
-  identity   Identity?       @relation(fields: [identityId], references: [slack])
-  quantity   Int             @default(0)
-  metadata   Json            @default("{}")
-  public     Boolean         @default(true)
-  trades     TradeInstance[]
-  crafting   RecipeItem[]
+  id               Int             @id @default(autoincrement())
+  itemId           String
+  identityId       String?
+  item             Item            @relation(fields: [itemId], references: [name])
+  identity         Identity?       @relation(fields: [identityId], references: [slack])
+  quantity         Int             @default(0)
+  metadata         Json            @default("{}")
+  public           Boolean         @default(true)
+  trades           TradeInstance[]
+  crafting         RecipeItem[]
+  offersToGive    InstanceOfferToGive[]
+  offersToReceive InstanceOfferToReceive[]
 }
 
 model Skill {
@@ -184,4 +186,31 @@ model Logger {
   id       Int          @id @default(autoincrement())
   level    LoggerLevels @default(GENERAL)
   contents String
+}
+
+model Offer {
+  id                 Int        @id @default(autoincrement())
+  sourceIdentityId   String
+  targetIdentityId   String
+  instancesToGive    InstanceOfferToGive[]
+  instancesToReceive InstanceOfferToReceive[]
+  callbackUrl        String?
+}
+
+model InstanceOfferToGive {
+  instanceId Int
+  offerId    Int
+  instance   Instance @relation(fields: [instanceId], references: [id])
+  offer      Offer    @relation(fields: [offerId], references: [id])
+  
+  @@id([instanceId, offerId])
+}
+
+model InstanceOfferToReceive {
+  instanceId Int
+  offerId    Int
+  instance   Instance @relation(fields: [instanceId], references: [id])
+  offer      Offer    @relation(fields: [offerId], references: [id])
+  
+  @@id([instanceId, offerId])
 }

--- a/proto/bag.proto
+++ b/proto/bag.proto
@@ -37,6 +37,7 @@ service BagService {
   rpc RunGive(RunGiveRequest) returns (RunGiveResponse) {}
   rpc RunCraft(RunCraftRequest) returns (RunCraftResponse) {}
   rpc GetCraftStatus(GetCraftStatusRequest) returns (GetCraftStatusResponse) {}
+  rpc MakeOffer(MakeOfferRequest) returns (MakeOfferResponse) {}
 }
 
 message App {
@@ -553,4 +554,19 @@ message GetCraftStatusRequest {
 message GetCraftStatusResponse {
   optional string response = 1;
   optional bool crafting = 2;
+}
+
+message MakeOfferRequest {
+  int32 appId = 1;
+  string key = 2;
+  string sourceIdentityId = 3;
+  string targetIdentityId = 4;
+  repeated Instance offerToGive = 5;
+  repeated Instance offerToReceive = 6;
+  optional string callbackUrl = 7;
+}
+
+message MakeOfferResponse {
+  optional string response = 1;
+  bool success = 2;
 }


### PR DESCRIPTION
This adds an endpoint that lets a bot make a take-it-or-leave-it offer to somebody. The offer request shows up in the target's DMs, and when an offer is accepted or declined, a callback url is POSTed to with either `accepted: true` or `accepted: false` depending on what the target did.

In all likelihood, several crimes against Prisma were committed in the development of this feature.